### PR TITLE
Add Component Labels to Picker Items

### DIFF
--- a/src/components/builderPage/builderPage.css
+++ b/src/components/builderPage/builderPage.css
@@ -21,22 +21,30 @@
                 .item {
                     position: relative;
                     border-bottom: 2px solid grey;
-                    padding-bottom: 5px;
-                    max-height: 100px;
                     padding-block: 10px;
-                    height: 100px;
+                    height: auto;
                     display: flex;
+                    flex-wrap: wrap;
                     align-items: center;
-                    gap: 15px;
+                    row-gap: 0;
+                    column-gap: 10px;
+
+                    .label {
+                        flex: 1 0 100%;
+                        font-size: .7em;
+                        font-variant: small-caps;
+                        line-height: 1m;
+                    }
 
                     .component {
                         border: 1px dotted gray;
                         border-radius: 5px;
                         position: relative;
-                        height: 100%;
-                        flex: 1 1 auto;
+                        height: 100px;
+                        flex: 1 1 80%;
                         textarea {
                             width: 100%;
+                            height: 100%;
                         }
                         .addItem {
                             flex: 1 0 auto;

--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -8,7 +8,7 @@ import "../../../node_modules/react-resizable/css/styles.css";
 
 //CS BLOCKS
 import LabelInput from "../draggables/labelInput";
-import Textarea from "../draggables/textarea";
+import TextArea from "../draggables/textarea";
 import StatInput from "../draggables/statInput";
 import EmptySpace from "../draggables/emptySpace";
 
@@ -23,7 +23,7 @@ const buildingBlocks = [
         height: 2
     },
     {
-        name: "Textarea",
+        name: "TextArea",
         width: 6,
         height: 6
     },
@@ -111,7 +111,7 @@ class Builder extends Component {
     renderComponent = (name, key) => {
         const components = {
             LabelInput: <LabelInput key={key}/>,
-            Textarea: <Textarea key={key}/>,
+            TextArea: <TextArea key={key}/>,
             StatInput: <StatInput key={key}/>,
             EmptySpace: <EmptySpace key={key}/>
         };
@@ -124,6 +124,7 @@ class Builder extends Component {
             <div className="picker">
                 {buildingBlocks.map((block, index) => {
                         return <div className="item" key={index}>
+                            <div className='label'>{block.name}</div>
                             <div className="component">
                                 {this.renderComponent(block.name, index)}
                             </div>


### PR DESCRIPTION
This adds the component/item names to the picker.  I think this will improve discussions around development and teaching future users, having clearly labelled names.  In the future we could add another object key to the components with better label text, but I didn't want to worry about that yet.

<img width="389" alt="image" src="https://github.com/5e-Cleric/Axe/assets/58999374/628312a9-351d-4227-8a3e-d7fb9de0f401">
